### PR TITLE
switching to hutch favicon

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -8,7 +8,7 @@ bibliography: [book.bib]
 biblio-style: apalike
 link-citations: yes
 description: "Description about Course/Book."
-favicon: assets/dasl_favicon.ico
+favicon: assets/favicon.ico
 ---
 
 # About this Course {-}


### PR DESCRIPTION
Wanted the favicon to match the NIH data sharing course - currently it is the old dasl icon ... now it is the hutch one. Is that ok with others?
