### PR TITLE
[Ethics] Add ISCB guidelines

### DIFF
--- a/02-ethics.Rmd
+++ b/02-ethics.Rmd
@@ -40,6 +40,8 @@ Note that this is an incomplete list; additional ethical concerns will become ap
 
 :::{.ethics}
 Be transparent about what AI tools you use to write code. This help others to better understand how you created your code, as well as the possible sources that the AI tools might have used when helping you write code. It may also help with future unknown issues related to the use of these tools.
+
+Some organizations and scientific societies have created guidelines for using AI in journal articles and conference submissions, like the [International Society for Computational Biology](https://www.iscb.org/iscb-policy-statements/iscb-policy-for-acceptable-use-of-large-language-models). Be responsible and follow these guidelines for your field.
 :::
 
 **It is essential to address these ethical concerns and ensure that the use of AI in coding is done in a responsible and transparent manner.** This could be done through ensuring the quality of the data used to train AI systems, promoting transparency in AI-generated code, and implementing safeguards against the creation of harmful or biased code. By doing so, we can harness the potential of AI to improve and transform the way we write and optimize code while maintaining ethical standards.

--- a/02-ethics.Rmd
+++ b/02-ethics.Rmd
@@ -41,7 +41,7 @@ Note that this is an incomplete list; additional ethical concerns will become ap
 :::{.ethics}
 Be transparent about what AI tools you use to write code. This help others to better understand how you created your code, as well as the possible sources that the AI tools might have used when helping you write code. It may also help with future unknown issues related to the use of these tools.
 
-Some organizations and scientific societies have created guidelines for using AI in journal articles and conference submissions, like the [International Society for Computational Biology](https://www.iscb.org/iscb-policy-statements/iscb-policy-for-acceptable-use-of-large-language-models). Be responsible and follow these guidelines for your field.
+Some organizations and scientific societies have created guidelines or requirements for using AI in journal articles and conference submissions, like the [International Society for Computational Biology](https://www.iscb.org/iscb-policy-statements/iscb-policy-for-acceptable-use-of-large-language-models). Be aware of the requirements/guidelines for your field.
 :::
 
 **It is essential to address these ethical concerns and ensure that the use of AI in coding is done in a responsible and transparent manner.** This could be done through ensuring the quality of the data used to train AI systems, promoting transparency in AI-generated code, and implementing safeguards against the creation of harmful or biased code. By doing so, we can harness the potential of AI to improve and transform the way we write and optimize code while maintaining ethical standards.


### PR DESCRIPTION
Added a link to the new ISCB guidelines on using AI for writing and conference submissions, as well as a statement that users need to follow the guidelines for their fields. Resolves issue #75 