### PR TITLE
Adding warnings about proprietary code

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -77,7 +77,7 @@ The methods used for chatbots have evolved over time. Now chatbots often utilize
 Despite the fact that chatbots have been around awhile, the popularity of OpenAI's ChatGPT and DALL-E programs has sparked a recent surge of interest. These chatbots are in part particularly powerful due to the fact that large amounts of computing power were used to train their NLP models on very large datasets [@caldarini2022literature; @cahn2017chatbot]. Large language model AIs can be divided into two categories: those that can be reached using an internet browser, and those that can be reached using an integrated development environment (IDE).
 
 ::: warning
-The information presented in this course is meant for use with open source code and software. It is unclear what happens to the information fed to AI chatbots as prompts, or how secure the data are. We know data are saved and may be used to further train the AI tools, but the specifics of how data are saved and how sensitive or personally identifiable information are protected.
+The information presented in this course is meant for use with open source code and software. It is unclear what happens to the information fed to AI chatbots as prompts, or how secure the data are. We know data are saved and may be used to further train the AI tools, but the specifics of how data are saved, as well as how sensitive or personally identifiable information are protected, is unknown.
 
 Err on the side of caution when interacting with them. We do **not** recommend using proprietary code or private information for prompts unless you are working with an AI that you or your company built and you know is secure.
 :::

--- a/04-refactoring.Rmd
+++ b/04-refactoring.Rmd
@@ -38,6 +38,12 @@ However, AI has significant potential to help with code refactoring. AI can use 
 
 AI refactoring is also faster and more accurate than manual refactoring. This is particularly useful for large-scale software projects with massive codebases, where manual code review and refactoring can be an enormous task. In the next sections, we'll take a look at some examples of using AI to refactor code.
 
+::: warning
+The information presented in this course is meant for use with open source code and software. It is unclear what happens to the information fed to AI chatbots as prompts, or how secure the data are. We know data are saved and may be used to further train the AI tools, but the specifics of how data are saved, as well as how sensitive or personally identifiable information are protected, is unknown.
+
+Err on the side of caution when interacting with them. We do **not** recommend using proprietary code or private information for prompts unless you are working with an AI that you or your company built and you know is secure.
+:::
+
 ## Example One: Correcting Syntax
 
 Programming languages operate using their established set of rules. For example, [Python](https://www.python.org/) uses indentation to define code blocks. However, when you shift between development environments, indentation and line breaks can sometimes be affected, causing major headaches! 

--- a/05-annotation.Rmd
+++ b/05-annotation.Rmd
@@ -19,6 +19,12 @@ There are many benefits to annotating code:
 - Improves maintainability
 - Improves quality
 
+::: warning
+The information presented in this course is meant for use with open source code and software. It is unclear what happens to the information fed to AI chatbots as prompts, or how secure the data are. We know data are saved and may be used to further train the AI tools, but the specifics of how data are saved, as well as how sensitive or personally identifiable information are protected, is unknown.
+
+Err on the side of caution when interacting with them. We do **not** recommend using proprietary code or private information for prompts unless you are working with an AI that you or your company built and you know is secure.
+:::
+
 ## Improves readability
 
 ```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "Dino says It’s great this code is well annotated using AI. I totally forgot what I was doing with this code when I wrote it. "}

--- a/06-understanding_other_ppl_code.Rmd
+++ b/06-understanding_other_ppl_code.Rmd
@@ -45,6 +45,12 @@ Keep these ethical considerations in mind when using AI to summarize code.
 **Does the code contain any sensitive or personal information?** If the code contains any sensitive or personal information, you should take special care to protect that information.
 ::: 
 
+::: warning
+The information presented in this course is meant for use with open source code and software. It is unclear what happens to the information fed to AI chatbots as prompts, or how secure the data are. We know data are saved and may be used to further train the AI tools, but the specifics of how data are saved, as well as how sensitive or personally identifiable information are protected, is unknown.
+
+Err on the side of caution when interacting with them. We do **not** recommend using proprietary code or private information for prompts unless you are working with an AI that you or your company built and you know is secure.
+:::
+
 ## Example One: Summarizing Code You Didn't Write
 
 Here's some simple code using the R programming language, written by an unnamed programmer. If you are familiar with R, you might be able to understand what this code does with little effort. However, if you don't know R, you're relatively new to R, or you're just having a bad day, understanding what this bit of code can take a great deal more energy and time. AI language bots can ease that burden.


### PR DESCRIPTION
This PR adds a warning box to the Refactoring, Annotating, and Understanding Other People's Code chapters. The warning box is the same one that is in the introduction and basically tells people that we have no idea how information entered as prompts into AI gets used or protected afterwards, so be cautious.