### PR TITLE
fix alt text for writing code chapter

### DIFF
--- a/03-writing_code.Rmd
+++ b/03-writing_code.Rmd
@@ -336,7 +336,7 @@ Is `here::here("raw", "data.csv")` equivalent to `here::here("raw/data.csv")`?
 
 First, let's see what [ChatGPT](https://chat.openai.com/) responded.
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT generates another way to do the same task."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT explains whether two ways of writing the same command in R are equivalent."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g230c4a00725_31_88")
 ```
 
@@ -345,7 +345,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWD
 
 When we first started putting together this course, we had intended to include an answer from [Bard](https://bard.google.com/) that disagreed with the answer from ChatGPT as an example of why it can be helpful to query multiple chatbots. (We decided ChatGPT was correct after verifying its answer in the `here` package documentation.) However, when we queried Bard again two weeks later, we were pleasantly surprised to discover that Bard had corrected its answer. Now it's a cool little example of how the chatbots are rapidly improving and "learning" from their mistakes.
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT generates another way to do the same task."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "Bard offers two different answers about whether syntaxes are equivalent. The first answer was incorrect, but the answer two weeks later had changed and now had the correct information."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g230c4a00725_31_84")
 ```
 
@@ -361,7 +361,7 @@ A very common task for anyone working with genomic samples is to combine multipl
 Can you write a program that merges vcf files and then outputs the sample names?
 :::
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT generates another way to do the same task."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT writes a program using bcftools that merges vcf files and outputs the sample names."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g230c4a00725_31_34")
 ```
 
@@ -381,7 +381,7 @@ What's another way I can do this?
 :::
 
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT generates code that allows you to merge vcf files and output the sample names."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT generates different code that allows you to merge vcf files and output the sample names."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g230c4a00725_31_77")
 ```
 


### PR DESCRIPTION
Some of the alt text for images in the earlier part of the chapter was incorrect. This fixes that.