### PR TITLE
Fix alt text in annotation chapter

### DIFF
--- a/05-annotation.Rmd
+++ b/05-annotation.Rmd
@@ -296,7 +296,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWD
 ```
 It not only provided helpful annotations but it fixed spacing and added more spaces between lines of code:
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "I asked ChatGPT to annotate old R code."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT provided annotations for the code I provided."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g22de39942ac_19_91")
 ```
 
@@ -313,7 +313,7 @@ How could I make this code better?
 
 It had a lot of great advice:
 
-```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "I asked ChatGPT to annotate old R code."}
+```{r, fig.align='center', out.width="100%", echo = FALSE, fig.alt= "ChatGPT offered ways to improve my old code."}
 ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWDLOGTcx3aLEbnu8UttV0QGVAeafE/edit#slide=id.g22de39942ac_19_79")
 ```
 
@@ -334,7 +334,7 @@ and it told me:
 You are correct that the tidyverse functions are designed to work with data frames and not matrices. Here's a modified version of your code that converts the matrix to a data frame and uses tidyverse functions:
 ```
 
-The lesson here is that the output of chatGPT still needs to be vetted by the person asking for it. It is a great idea to continue to have AI's work on something if it isn't quite what you are asking for, however, at the end of the day it is you, the human, who has to vet the output.
+The lesson here is that the output of chatGPT still needs to be vetted by the person asking for it. It is a great idea to continue to have AIs work on something if it isn't quite what you are asking for, however, at the end of the day it is you, the human, who has to vet the output.
 
 ### Sometimes it has trouble with file types if given a URL
 


### PR DESCRIPTION
A couple of images had incorrect alt text descriptors. This PR adds the proper ones.