### PR TITLE
Fix spacing on lesson duration table

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -76,8 +76,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1MCNeSO4aOm1iESWD
 | [Refactoring Exercise](https://hutchdatascience.org/AI_for_software/refactoring-code.html#hands-on-exercise-1) | 15 minutes |
 | [Annotating Code](https://hutchdatascience.org/AI_for_software/annotating-your-code.html) | 25 minutes |
 | [Understanding Code](https://hutchdatascience.org/AI_for_software/understanding-unfamiliar-code.html) | 25 minutes |
-| [Understanding Exercise](https://hutchdatascience.org/AI_for_software/understanding-unfamiliar-code.html#hands-on-exercise-2) | 10
-minutes |
+| [Understanding Exercise](https://hutchdatascience.org/AI_for_software/understanding-unfamiliar-code.html#hands-on-exercise-2) | 10 minutes |
 | **Total** | 3 hours & 10 minutes |
 
 


### PR DESCRIPTION
The word "minutes" ended up on a line by itself at the very end of the table. This restores the proper spacing

