### PR TITLE
[Writing Code] Move notice box

### DIFF
--- a/03-writing_code.Rmd
+++ b/03-writing_code.Rmd
@@ -43,18 +43,18 @@ AI-powered programming tools and technologies are revolutionizing the way we app
 
 1. _AI can make programming more accessible._ With AI-generated code and automated programming tools, individuals who are not experienced developers can still create software solutions. Experienced developers can also more easily write code in languages with which they aren't familiar. This has the potential to democratize programming and lead to new innovations from a wider range of people.
 
-:::{.notice}
-Can complete novices learn how to program using AI tools?
-
-At present, it is very challenging for complete novices to rely on AI chatbots to learn how to write code. These tools will sometimes write buggy code or code that doesn't not work as intended, and a person with no programming experience will have difficulty learning how to spot these sorts of mistakes. AI chatbots are best thought of as a supplement to your software development education, not as a replacement, and they should be used alongside other resources. Therefore, we advise that you seek expert review and assistance. As AI tools are refined, complete novices may be able to create software products more readily on their own.
-:::
-
 1. _AI is changing the skills required for writing code._ Rather than simply memorizing syntax, developers need to focus on developing their creativity, intuition, and problem-solving skills. Additionally, programmers must also hone their abilities in architecture design and project management, as these skills are becoming increasingly important in the modern software development landscape.
 
 As AI continues to evolve, it is likely to have an even greater impact on the way we develop software in the future.
 
 :::{.ethics}
 **As a programmer using AI, it is up to you to be responsible for what you create.** You must rigorously test any code you write. It is your job to make sure any code you create with AI is not malicious and works as expected.
+:::
+
+:::{.notice}
+Can complete novices learn how to program using AI tools?
+
+At present, it is very challenging for complete novices to rely on AI chatbots to learn how to write code. These tools will sometimes write buggy code or code that doesn't not work as intended, and a person with no programming experience will have difficulty learning how to spot these sorts of mistakes. AI chatbots are best thought of as a supplement to your software development education, not as a replacement, and they should be used alongside other resources. Therefore, we advise that you seek expert review and assistance. As AI tools are refined, complete novices may be able to create software products more readily on their own.
 :::
 
 ## Tips for Coding with AI


### PR DESCRIPTION
I moved the notice box about novices learning to write code with AI to the bottom of the "Writing Code with AI" section. The current location breaks things up a little too much and makes it look confusing on Leanpub.
