### PR TITLE
[General] Changing course name

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Efficient Programming with AI"
+title: "AI for Efficient Programming"
 subtitle: "Harnessing the Power of Large Language Models"
 date: "`r format(Sys.time(), '%B, %Y')`"
 site: bookdown::bookdown_site


### PR DESCRIPTION
Just changing the course name from "Efficient Programming with AI" to "AI for Efficient Programming". Carrie pointed out the latter title will jump out more when people search